### PR TITLE
ci(build-deb): build inside bookworm + publish to jambonz apt-repo

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -1,44 +1,84 @@
 name: Build Debian Package
 
+# Triggers:
+#   - workflow_dispatch (manual run from the Actions tab)
+#   - push of a tag matching v* (matches drachtio's convention; bare numeric
+#     tags from this repo's history will NOT trigger builds — use v1.9.0)
 on:
   workflow_dispatch:
   push:
     tags:
-      - '[0-9]*'
+      - 'v*'
+
+# Serialize concurrent runs so simultaneous tag pushes don't race the
+# apt-repo dispatch / S3 upload.
+concurrency:
+  group: build-deb
+  cancel-in-progress: false
 
 jobs:
   build-deb:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    # Build inside a Debian bookworm container so the produced .deb links
+    # against the libs customers run on bookworm (libssl3, libstdc++6,
+    # libev, etc.) — not noble's newer libs.
+    container:
+      image: debian:bookworm
+    # debian/rules builds libwebsockets v4.3.3 AND aws-sdk-cpp v1.11.500
+    # from source via `sudo make install`. Combined build is ~30-60min.
+    timeout-minutes: 90
 
     steps:
+      - name: Bootstrap container
+        # debian:bookworm is minimal — install the tools the rest of the
+        # workflow needs. `sudo` must exist on PATH because debian/rules
+        # invokes `sudo make install` for libwebsockets and aws-sdk-cpp
+        # during build (the runner is already root inside the container,
+        # but sudo is still required for the literal command).
+        run: |
+          apt-get update -qq
+          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+              git curl ca-certificates gnupg awscli sudo xz-utils
+
       - name: Checkout code
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - name: Get version from git
+      - name: Get version from git tag
         id: version
         run: |
-          VERSION=$(git describe --tags --always 2>/dev/null || echo "0.0.1")
-          # Remove leading 'v' if present
+          # GitHub's container support mounts the workspace owned by a uid
+          # the container's git considers 'dubious'. Allow it explicitly so
+          # `git describe` works.
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          # Prefer the actual triggering tag if we're on one (most common
+          # for production runs); fall back to git describe for manual
+          # workflow_dispatch runs.
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            VERSION="${{ github.ref_name }}"
+          else
+            VERSION=$(git describe --tags --always 2>/dev/null || echo "0.0.1")
+          fi
+          # Debian package versions must start with a digit. Strip 'v'.
           VERSION=${VERSION#v}
           echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
           echo "Building version: ${VERSION}"
 
       - name: Update debian changelog
         run: |
-          cat > debian/changelog << EOF
-          upload-recordings (${{ steps.version.outputs.VERSION }}) unstable; urgency=medium
+          cat > debian/changelog <<EOF
+          upload-recordings (${{ steps.version.outputs.VERSION }}) bookworm; urgency=medium
 
             * Release ${{ steps.version.outputs.VERSION }}
 
            -- Dave Horton <daveh@beachdognet.com>  $(date -R)
           EOF
+          head -3 debian/changelog
 
       - name: Install build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
+          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
             build-essential \
             devscripts \
             debhelper \
@@ -54,7 +94,6 @@ jobs:
             libfmt-dev \
             libssl-dev \
             libcurl4-openssl-dev \
-            libunwind-dev \
             libgoogle-perftools-dev \
             libboost-all-dev \
             libev-dev
@@ -65,13 +104,41 @@ jobs:
 
       - name: Prepare artifacts
         run: |
-          cp ../upload-recordings*.deb .
-          ls -la upload-recordings*.deb
+          mkdir -p artifacts
+          cp ../upload-recordings_*.deb artifacts/ 2>/dev/null || true
+          cd artifacts
+          for d in *.deb; do
+            sha256sum "$d" > "${d}.sha256"
+          done
+          ls -lh
+
+      - name: Upload to S3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_S3_REGION }}
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        run: |
+          # Trim any trailing whitespace/newline from the bucket value
+          # (GitHub secrets sometimes get saved with stray whitespace).
+          BUCKET=$(printf '%s' "$AWS_S3_BUCKET" | tr -d '[:space:]')
+          aws s3 cp artifacts/ "s3://${BUCKET}/upload-recordings/" \
+              --recursive --include "*.deb" --include "*.sha256"
 
       - name: Upload to GitHub Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
-          files: upload-recordings_*.deb
+          files: artifacts/*.deb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger apt repo refresh
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer ${{ secrets.APT_REPO_PAT }}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/jambonz/apt-repo/dispatches \
+            -d '{"event_type":"package-uploaded","client_payload":{"repo":"${{ github.repository }}","tag":"${{ github.ref_name }}"}}'


### PR DESCRIPTION
## Summary

- Build the `.deb` inside a `debian:bookworm` container on `ubuntu-24.04`, so the produced binary links against bookworm's libs — not ubuntu-22.04's. Customer machines run Debian 12; mismatched ABIs would surface as library-load failures at install time.
- After build, upload `*.deb` + `*.sha256` to `s3://<bucket>/upload-recordings/` and fire `repository_dispatch` (event_type `package-uploaded`) at `jambonz/apt-repo`. That triggers the apt index rebuild so `apt update && apt install upload-recordings` works for customers.
- Add `concurrency: build-deb` (serializes simultaneous tag pushes against the apt-repo dispatch) and `timeout-minutes: 90` (libwebsockets v4.3.3 + aws-sdk-cpp v1.11.500 build from source — typically 30-60min).

## Convention change — heads up

Tag pattern switched from `[0-9]*` → `v*` to match `jambonz/drachtio-server`. **Future stable tags must be `v1.9.0`, not `1.9.0`.** Bare numerics will no longer trigger CI.

The produced `.deb` filename is unchanged (`upload-recordings_1.9.0_amd64.deb`) — the workflow strips the leading `v` before writing `debian/changelog`.

## Required secrets

Already configured in `jambonz/rtpengine`; need to be set on this repo too:

- `AWS_ACCESS_KEY_ID`
- `AWS_SECRET_ACCESS_KEY`
- `AWS_S3_REGION`
- `AWS_S3_BUCKET`
- `APT_REPO_PAT` (PAT with `repo` scope, used to dispatch at `jambonz/apt-repo`)

## Known follow-up — NOT in this PR

`debian/rules` runs `sudo make install` of libwebsockets and aws-sdk-cpp into `/usr/local/lib` during build, but `override_dh_auto_install` only packages `/usr/bin/upload_recordings`. On a fresh customer Debian 12 box those `.so` files are missing → `upload_recordings` fails at startup with library-not-found.

Two options for a follow-up issue:
1. Bundle the libs into `upload-recordings.deb` itself (extend `override_dh_auto_install` to copy `/usr/local/lib/{libwebsockets*,libaws-cpp-sdk*}.so*`).
2. Split into a sibling `upload-recordings-deps.deb` and `Depends:` on it.

Recommend option 1 plus a CI smoke test (`dpkg -i artifacts/*.deb` + `upload_recordings --help` on a fresh `debian:bookworm`).

## Test plan

- [ ] Merge this PR, then push tag `v1.8.1` (or whatever the next version is).
- [ ] CI runs to completion within ~60min.
- [ ] `s3://<bucket>/upload-recordings/upload-recordings_1.8.1_amd64.deb` and `.sha256` appear.
- [ ] `jambonz/apt-repo` `Publish apt repository` workflow triggers automatically and lists `upload-recordings_1.8.1_amd64.deb` in its "=== .debs found ===" output.
- [ ] On a fresh Debian 12 box with the jambonz apt source: `apt update && apt install -y upload-recordings` resolves cleanly.
- [ ] (Expected to fail until the lib-bundling follow-up): `/usr/bin/upload_recordings --help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
