### PR TITLE
debian/rules: bundle libwebsockets + aws-sdk-cpp .so files in the deb

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -44,6 +44,30 @@ override_dh_auto_build:
 override_dh_auto_install:
 	install -D -m755 build/upload_recordings debian/upload-recordings/usr/bin/upload_recordings
 	install -D -m644 upload_recordings.service debian/upload-recordings/usr/share/doc/upload-recordings/examples/upload_recordings.service
+	# Bundle the libs we built from source (libwebsockets v4.3.3 + custom
+	# ops-ws.c patch, aws-sdk-cpp v1.11.500 and its aws-c-* deps). They
+	# aren't packaged for Debian 12, and the binary would otherwise fail
+	# at startup with "library not found" on a fresh customer box.
+	#
+	# Path: /usr/lib/upload-recordings/ — a private dir, NOT /usr/local/lib.
+	# jambonz-freeswitch.deb already ships the same .so files at
+	# /usr/local/lib/, so we'd hit dpkg file conflicts on a single-host
+	# (jambonz-mini) install. The /etc/ld.so.conf.d/ entry below adds the
+	# private dir to the system-wide ld.so search path so the binary picks
+	# them up automatically — no LD_LIBRARY_PATH needed in the service unit.
+	install -d -m 755 debian/upload-recordings/usr/lib/upload-recordings
+	cp -a /usr/local/lib/libwebsockets*.so*    debian/upload-recordings/usr/lib/upload-recordings/
+	cp -a /usr/local/lib/libaws-c-*.so*        debian/upload-recordings/usr/lib/upload-recordings/
+	cp -a /usr/local/lib/libaws-checksums*.so* debian/upload-recordings/usr/lib/upload-recordings/
+	cp -a /usr/local/lib/libaws-cpp-sdk*.so*   debian/upload-recordings/usr/lib/upload-recordings/
+	cp -a /usr/local/lib/libaws-crt-cpp*.so*   debian/upload-recordings/usr/lib/upload-recordings/
+	cp -a /usr/local/lib/libs2n*.so*           debian/upload-recordings/usr/lib/upload-recordings/
+	# ld.so search-path entry. dpkg will fire the ldconfig trigger on
+	# install/upgrade automatically once this file is present, so no
+	# explicit postinst is needed.
+	install -d -m 755 debian/upload-recordings/etc/ld.so.conf.d
+	echo "/usr/lib/upload-recordings" > debian/upload-recordings/etc/ld.so.conf.d/upload-recordings.conf
+	chmod 644 debian/upload-recordings/etc/ld.so.conf.d/upload-recordings.conf
 
 override_dh_auto_clean:
 	rm -rf build

--- a/upload_recordings.service
+++ b/upload_recordings.service
@@ -10,12 +10,15 @@ Environment="MYSQL_DATABASE=jambones"
 Environment="BASIC_AUTH_USERNAME=xxxxx"
 Environment="BASIC_AUTH_PASSWORD=xxxxx"
 Environment="ENCRYPTION_SECRET=xxxxxx"
-ExecStart=/usr/local/bin/upload_recordings --port 3017
+# When installed via the .deb, the binary lives at /usr/bin/upload_recordings
+# and its bundled .so dependencies are at /usr/lib/upload-recordings/, found
+# automatically via /etc/ld.so.conf.d/upload-recordings.conf. No LD_LIBRARY_PATH
+# is required.
+ExecStart=/usr/bin/upload_recordings --port 3017
 Restart=always
 RestartSec=5
-User=admin
-Group=admin
-WorkingDirectory=/usr/local/bin
+User=root
+Group=daemon
 StandardOutput=journal
 StandardError=journal
 


### PR DESCRIPTION
## Summary

Make `upload-recordings.deb` self-contained by bundling its runtime libs (libwebsockets v4.3.3 with the custom `ops-ws.c` patch, and aws-sdk-cpp v1.11.500 + its `aws-c-*` deps) into the .deb itself.

Without this, `dpkg-shlibdeps --ignore-missing-info` lets the build succeed, but on a fresh Debian 12 customer box the binary fails at startup with "library not found" — those .so files aren't in any Debian apt repo. Confirmed live: the v1.8.1 deb in our apt repo only ships the 343KB binary, no libs.

## Why a private dir

Libs land at `/usr/lib/upload-recordings/`, not `/usr/local/lib/`. `jambonz-freeswitch.deb` already ships the *same* .so files (libwebsockets.so.19, libaws-cpp-sdk-*, libs2n, etc.) under `/usr/local/lib/`. On a single-host `jambonz-mini` install both packages are present — using the same path would trigger dpkg file-conflict errors. The private dir is conflict-free in both topologies.

A `/etc/ld.so.conf.d/upload-recordings.conf` adds the dir to ld.so's system-wide search path; dpkg's ldconfig trigger handles refresh on install/upgrade automatically. **No `LD_LIBRARY_PATH` is required in the service unit.**

## Multi-host vs single-host

| Topology | upload_recordings location | freeswitch on same box | This deb's libs needed? |
|---|---|---|---|
| `jambonz-mini` | localhost | yes | yes (FS uses /usr/local/lib; we use /usr/lib/upload-recordings — no conflict) |
| Cluster | dedicated box | **no** | yes (mandatory — FS isn't there) |

So self-contained bundling is mandatory regardless of FS's contents.

## Trade-off

- **Disk cost on `jambonz-mini`**: ~150-300MB duplicated between this deb and `jambonz-freeswitch` (same lib set, just at different paths). Acceptable for now.
- **Future cleanup**: if the duplication becomes a problem, extract into a shared `jambonz-libs.deb` consumed by both. Out of scope here per offline discussion.

## Test plan

- [ ] Tag `v1.8.2`. CI build produces a much larger `.deb` (~150-300MB vs the current 343KB) — that itself is the smoke test that lib bundling kicked in.
- [ ] On a fresh `debian:bookworm` container: `dpkg -i upload-recordings_1.8.2_amd64.deb`, then `ldd /usr/bin/upload_recordings` — no "not found" lines, all libs resolve under `/usr/lib/upload-recordings/`.
- [ ] `/usr/bin/upload_recordings --port 3017` starts and binds without crashing.
- [ ] On `jambonz-mini`: install both jambonz-freeswitch and upload-recordings — no dpkg conflict, both services start clean.

## Side-effect

Updates the example `upload_recordings.service` shipped under `/usr/share/doc/upload-recordings/examples/` to reflect the .deb's actual layout (binary at `/usr/bin/`, no LD_LIBRARY_PATH, root/daemon user/group matching the version `jambonz-mini.deb` ships). Doc-only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
