### PR TITLE
fix: use configured upload folder for MP3/WAV encoding temp files

### DIFF
--- a/azure-uploader.cpp
+++ b/azure-uploader.cpp
@@ -127,8 +127,8 @@ bool AzureUploader::upload(std::vector<char>& data, bool isFinalChunk) {
       log_->info("Encoding PCM data to MP3 format using streaming");
       
       // Create a unique temporary file for the MP3
-      char mp3TempFilePath[] = "/tmp/azure-mp3file-XXXXXX";
-      int mp3TempFd = mkstemp(mp3TempFilePath);
+      std::string mp3TempPath;
+      int mp3TempFd = createMkstempFile("mp3file", mp3TempPath);
       if (mp3TempFd == -1) {
         log_->error("Failed to create unique MP3 temporary file: {}", std::strerror(errno));
         upload_failed_ = true;
@@ -136,46 +136,46 @@ bool AzureUploader::upload(std::vector<char>& data, bool isFinalChunk) {
         return false;
       }
       close(mp3TempFd); // Close the descriptor as we'll use the encoder's file methods
-      
+
       try {
         // Create streaming MP3 encoder with metadata parameters
         // Using 2 channels and 128 kbps as before
         StreamingMp3Encoder encoder(metadata_.sample_rate, 2, 128, log_);
-        
+
         // Get the size of the PCM file for logging
         auto pcmFileSize = std::filesystem::file_size(tempFilePath_);
         log_->info("Starting streaming MP3 encoding of {} bytes of PCM data", pcmFileSize);
-        
+
         // Encode the file using streaming (reads and writes in chunks)
-        encoder.encodeFile(tempFilePath_, mp3TempFilePath);
-        
+        encoder.encodeFile(tempFilePath_, mp3TempPath);
+
         // Get the size of the resulting MP3 file
-        auto mp3FileSize = std::filesystem::file_size(mp3TempFilePath);
-        
+        auto mp3FileSize = std::filesystem::file_size(mp3TempPath);
+
         // Update the final file path to point to the MP3 file
-        finalFilePath = mp3TempFilePath;
+        finalFilePath = mp3TempPath;
         log_->info("Successfully encoded {} bytes of PCM to {} bytes of MP3", pcmFileSize, mp3FileSize);
-        
+
       } catch (const std::exception& e) {
         log_->error("MP3 encoding failed: {}", e.what());
-        std::remove(mp3TempFilePath);
+        std::remove(mp3TempPath.c_str());
         upload_failed_ = true;
         cleanupTempFile();
         return false;
       }
     }
     else if (recordFileType_ == RecordFileType::WAV) {
-      char wavTempFilePath[] = "/tmp/azure-wavfile-XXXXXX";
-      int wavTempFd = mkstemp(wavTempFilePath);
+      std::string wavTempPath;
+      int wavTempFd = createMkstempFile("wavfile", wavTempPath);
       if (wavTempFd == -1) {
         log_->error("Failed to create unique WAV temporary file: {}", std::strerror(errno));
         upload_failed_ = true;
         cleanupTempFile();
         return false;
       }
-      std::ofstream wavTempFile(wavTempFilePath, std::ios::binary);
+      std::ofstream wavTempFile(wavTempPath, std::ios::binary);
       if (!wavTempFile) {
-        log_->error("Failed to open WAV temporary file: {}", wavTempFilePath);
+        log_->error("Failed to open WAV temporary file: {}", wavTempPath);
         close(wavTempFd);
         upload_failed_ = true;
         cleanupTempFile();
@@ -189,7 +189,7 @@ bool AzureUploader::upload(std::vector<char>& data, bool isFinalChunk) {
       // Write header then raw audio.
       wavTempFile.write(wavHeader.data(), wavHeader.size());
       if (!wavTempFile.good()) {
-        log_->error("Failed to write WAV header to temporary file: {}", wavTempFilePath);
+        log_->error("Failed to write WAV header to temporary file: {}", wavTempPath);
         close(wavTempFd);
         upload_failed_ = true;
         cleanupTempFile();
@@ -207,8 +207,8 @@ bool AzureUploader::upload(std::vector<char>& data, bool isFinalChunk) {
       wavTempFile.close();
       rawAudioFile.close();
       close(wavTempFd);
-      log_->info("WAV file created with header at: {}", wavTempFilePath);
-      finalFilePath = wavTempFilePath;
+      log_->info("WAV file created with header at: {}", wavTempPath);
+      finalFilePath = wavTempPath;
     }
 
     // Build the full upload URL.

--- a/google-uploader.cpp
+++ b/google-uploader.cpp
@@ -185,8 +185,8 @@ void GoogleUploader::finalizeUpload() {
     log_->info("Encoding PCM data to MP3 format using streaming");
     
     // Create a unique temporary file for the MP3
-    char mp3TempFilePath[] = "/tmp/uploads/mp3file-XXXXXX";
-    int mp3TempFd = mkstemp(mp3TempFilePath);
+    std::string mp3TempPath;
+    int mp3TempFd = createMkstempFile("mp3file", mp3TempPath);
     if (mp3TempFd == -1) {
       log_->error("Failed to create unique MP3 temporary file using mkstemp: {}", std::strerror(errno));
       upload_failed_ = true;
@@ -194,46 +194,46 @@ void GoogleUploader::finalizeUpload() {
       return;
     }
     close(mp3TempFd); // Close the descriptor as we'll use the encoder's file methods
-    
+
     try {
       // Create streaming MP3 encoder with metadata parameters
       // Using 2 channels and 128 kbps as before
       StreamingMp3Encoder encoder(metadata_.sample_rate, 2, 128, log_);
-      
+
       // Get the size of the PCM file for logging
       auto pcmFileSize = std::filesystem::file_size(tempFilePath_);
       log_->info("Starting streaming MP3 encoding of {} bytes of PCM data", pcmFileSize);
-      
+
       // Encode the file using streaming (reads and writes in chunks)
-      encoder.encodeFile(tempFilePath_, mp3TempFilePath);
-      
+      encoder.encodeFile(tempFilePath_, mp3TempPath);
+
       // Get the size of the resulting MP3 file
-      auto mp3FileSize = std::filesystem::file_size(mp3TempFilePath);
-      
+      auto mp3FileSize = std::filesystem::file_size(mp3TempPath);
+
       // Update the final file path to point to the MP3 file
-      finalFilePath = mp3TempFilePath;
+      finalFilePath = mp3TempPath;
       log_->info("Successfully encoded {} bytes of PCM to {} bytes of MP3", pcmFileSize, mp3FileSize);
-      
+
     } catch (const std::exception& e) {
       log_->error("MP3 encoding failed: {}", e.what());
-      std::remove(mp3TempFilePath);
+      std::remove(mp3TempPath.c_str());
       upload_failed_ = true;
       cleanupTempFile();
       return;
     }
   }
   else if (recordFileType_ == RecordFileType::WAV) {
-    char wavTempFilePath[] = "/tmp/uploads/wavfile-XXXXXX";
-    int wavTempFd = mkstemp(wavTempFilePath);
+    std::string wavTempPath;
+    int wavTempFd = createMkstempFile("wavfile", wavTempPath);
     if (wavTempFd == -1) {
       log_->error("Failed to create unique WAV temporary file using mkstemp: {}", std::strerror(errno));
       upload_failed_ = true;
       cleanupTempFile();
       return;
     }
-    std::ofstream wavTempFile(wavTempFilePath, std::ios::binary);
+    std::ofstream wavTempFile(wavTempPath, std::ios::binary);
     if (!wavTempFile) {
-      log_->error("Failed to open WAV temporary file: {}", wavTempFilePath);
+      log_->error("Failed to open WAV temporary file: {}", wavTempPath);
       close(wavTempFd);
       upload_failed_ = true;
       cleanupTempFile();
@@ -248,7 +248,7 @@ void GoogleUploader::finalizeUpload() {
     // Write the header.
     wavTempFile.write(wavHeader.data(), wavHeader.size());
     if (!wavTempFile.good()) {
-      log_->error("Failed to write WAV header to temporary file: {}", wavTempFilePath);
+      log_->error("Failed to write WAV header to temporary file: {}", wavTempPath);
       close(wavTempFd);
       upload_failed_ = true;
       cleanupTempFile();
@@ -267,8 +267,8 @@ void GoogleUploader::finalizeUpload() {
     wavTempFile.close();
     rawAudioFile.close();
     close(wavTempFd);
-    log_->info("WAV file created with header at: {}", wavTempFilePath);
-    finalFilePath = wavTempFilePath;
+    log_->info("WAV file created with header at: {}", wavTempPath);
+    finalFilePath = wavTempPath;
   }
 
   // Initiate a resumable upload session.

--- a/s3-compatible-uploader.cpp
+++ b/s3-compatible-uploader.cpp
@@ -165,8 +165,8 @@ void S3CompatibleUploader::finalizeUpload() {
             log_->info("Encoding PCM data to MP3 format using streaming");
             
             // Create a unique temporary file for the MP3
-            char mp3TempFilePath[] = "/tmp/uploads/mp3file-XXXXXX";
-            int mp3TempFd = mkstemp(mp3TempFilePath);
+            std::string mp3TempPath;
+            int mp3TempFd = createMkstempFile("mp3file", mp3TempPath);
             if (mp3TempFd == -1) {
                 log_->error("Failed to create unique MP3 temporary file using mkstemp: {}", strerror(errno));
                 upload_failed_ = true;
@@ -174,38 +174,37 @@ void S3CompatibleUploader::finalizeUpload() {
                 return;
             }
             close(mp3TempFd); // Close the descriptor as we'll use the encoder's file methods
-            
+
             try {
                 // Create streaming MP3 encoder with metadata parameters
                 // Using 2 channels and 128 kbps as before
                 StreamingMp3Encoder encoder(metadata_.sample_rate, 2, 128, log_);
-                
+
                 // Get the size of the PCM file for logging
                 auto pcmFileSize = std::filesystem::file_size(tempFilePath_);
                 log_->info("Starting streaming MP3 encoding of {} bytes of PCM data", pcmFileSize);
-                
+
                 // Encode the file using streaming (reads and writes in chunks)
-                encoder.encodeFile(tempFilePath_, mp3TempFilePath);
-                
+                encoder.encodeFile(tempFilePath_, mp3TempPath);
+
                 // Get the size of the resulting MP3 file
-                auto mp3FileSize = std::filesystem::file_size(mp3TempFilePath);
-                
+                auto mp3FileSize = std::filesystem::file_size(mp3TempPath);
+
                 // Update the final file path to point to the MP3 file
-                finalFilePath = mp3TempFilePath;
+                finalFilePath = mp3TempPath;
                 log_->info("Successfully encoded {} bytes of PCM to {} bytes of MP3", pcmFileSize, mp3FileSize);
-                
+
             } catch (const std::exception& e) {
                 log_->error("MP3 encoding failed: {}", e.what());
-                std::remove(mp3TempFilePath);
+                std::remove(mp3TempPath.c_str());
                 upload_failed_ = true;
                 cleanupTempFile();
                 return;
             }
         }
         else if (recordFileType_ == RecordFileType::WAV) {
-            // Use mkstemp to generate a unique temporary file for the WAV file
-            char wavTempFilePath[] = "/tmp/uploads/wavfile-XXXXXX"; // Template for unique file
-            int wavTempFd = mkstemp(wavTempFilePath); // Creates the file and returns a file descriptor
+            std::string wavTempPath;
+            int wavTempFd = createMkstempFile("wavfile", wavTempPath);
             if (wavTempFd == -1) {
                 log_->error("Failed to create unique WAV temporary file using mkstemp: {}", strerror(errno));
                 upload_failed_ = true;
@@ -214,9 +213,9 @@ void S3CompatibleUploader::finalizeUpload() {
             }
 
             // Open the file stream associated with the descriptor
-            std::ofstream wavTempFile(wavTempFilePath, std::ios::binary);
+            std::ofstream wavTempFile(wavTempPath, std::ios::binary);
             if (!wavTempFile) {
-                log_->error("Failed to open WAV temporary file: {}", wavTempFilePath);
+                log_->error("Failed to open WAV temporary file: {}", wavTempPath);
                 close(wavTempFd); // Close the file descriptor
                 upload_failed_ = true;
                 cleanupTempFile();
@@ -233,7 +232,7 @@ void S3CompatibleUploader::finalizeUpload() {
             // Write the WAV header to the new temporary file
             wavTempFile.write(wavHeader.data(), wavHeader.size());
             if (!wavTempFile.good()) {
-                log_->error("Failed to write WAV header to temporary file: {}", wavTempFilePath);
+                log_->error("Failed to write WAV header to temporary file: {}", wavTempPath);
                 close(wavTempFd); // Close the file descriptor
                 upload_failed_ = true;
                 cleanupTempFile();
@@ -255,7 +254,7 @@ void S3CompatibleUploader::finalizeUpload() {
             close(wavTempFd); // Close the descriptor after all writes
 
             // Update the final file path to point to the new WAV file
-            finalFilePath = wavTempFilePath;
+            finalFilePath = wavTempPath;
         }
 
         // Attach the file stream to the request body

--- a/storage-uploader.cpp
+++ b/storage-uploader.cpp
@@ -14,6 +14,7 @@ void StorageUploader::createTempFile(const std::string& uploadFolder) {
     try {
         // Determine the directory for the temp file
         fs::path tempDir = uploadFolder.empty() ? fs::temp_directory_path() : fs::path(uploadFolder);
+        uploadFolder_ = tempDir.string();
 
         // Generate a unique file name using the static atomic counter
         int counterValue = uniqueCounter.fetch_add(1, std::memory_order_relaxed);
@@ -127,4 +128,15 @@ std::string StorageUploader::stampAndSerializeSessionSummary(const std::string& 
     }
 
     return json.View().WriteCompact();
+}
+
+int StorageUploader::createMkstempFile(const std::string& prefix, std::string& outPath) {
+    std::string templatePath = (fs::path(uploadFolder_) / (prefix + "-XXXXXX")).string();
+    std::vector<char> buf(templatePath.begin(), templatePath.end());
+    buf.push_back('\0');
+    int fd = mkstemp(buf.data());
+    if (fd != -1) {
+        outPath.assign(buf.data());
+    }
+    return fd;
 }

--- a/storage-uploader.h
+++ b/storage-uploader.h
@@ -105,8 +105,13 @@ protected:
     std::chrono::system_clock::time_point audioStartTime_;
     bool audioStartTimeSet_ = false;
 
+    std::string uploadFolder_;
     std::string tempFilePath_;
     std::ofstream tempFile_;
+
+    // Create a mkstemp-compatible temp file in uploadFolder_ and return its fd and path.
+    // Returns -1 on failure.
+    int createMkstempFile(const std::string& prefix, std::string& outPath);
 
     // weak reference to the session so we can trigger its destruction after upload completion
     std::weak_ptr<Session> sessionRef_;


### PR DESCRIPTION
## Summary

- The `mkstemp` paths for intermediate MP3 and WAV temp files were hardcoded to `/tmp/uploads` (or `/tmp/azure-*`), ignoring `JAMBONZ_UPLOADER_TMP_FOLDER`. This meant `/tmp/uploads` had to exist even when a different folder was configured.
- Added `createMkstempFile()` helper to `StorageUploader` base class that builds mkstemp templates using the configured upload folder, and replaced hardcoded paths in all three uploaders (S3, Google, Azure).

## Test plan

- [x] Docker build compiles cleanly
- [x] Deployed patched binary to jambonz mini (10.10.148.2) with `JAMBONZ_UPLOADER_TMP_FOLDER=/var/lib/jambonz/s3uploads` and `/tmp/uploads` removed
- [x] Placed inbound SIP call via sipp, MP3 encoding succeeded using the configured folder
- [x] Recording uploaded to S3 (`jambonz-recordings-upload-testing` bucket)
- [x] Confirmed `/tmp/uploads` was never needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)